### PR TITLE
Add to yum-builddep support of .nosrc.rpm (#1298632)

### DIFF
--- a/yum-builddep.py
+++ b/yum-builddep.py
@@ -92,7 +92,7 @@ class YumBuildDep(YumUtilBase):
             self.logger.error("Error: You must be root to install packages")
             sys.exit(1)
 
-        if not all(cmd.endswith('.spec') or cmd.endswith('.src.rpm') for cmd in self.cmds):
+        if not all(cmd.endswith('.spec') or cmd.endswith('.src.rpm') or cmd.endswith('.nosrc.rpm') for cmd in self.cmds):
             # Use source rpms
             self.arch.archlist.append('src')
             self.setupSourceRepos()
@@ -191,7 +191,7 @@ class YumBuildDep(YumUtilBase):
             reloadworks = True
 
         for arg in self.cmds:
-            if arg.endswith('.src.rpm'):
+            if arg.endswith('.src.rpm') or arg.endswith('.nosrc.rpm'):
                 try:
                     srpms.append(yum.packages.YumLocalPackage(self.ts, arg))
                 except yum.Errors.MiscError, e:


### PR DESCRIPTION
Since yum-utils still exist and works fine in RHEL/CentOS, it is cool to fix this bug also.

Also, it resolves RH BZ 1298632