### PR TITLE
Add to binaries -deprecated surfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ install:
 	mkdir -p $(DESTDIR)/usr/sbin/
 	mkdir -p $(DESTDIR)/usr/share/man/man1
 	for util in $(UTILS); do \
-		install -m 755 $$util.py $(DESTDIR)/usr/bin/$$util; \
+		install -m 755 $$util.py $(DESTDIR)/usr/bin/$$util-deprecated; \
 	done
 	for util in $(UTILSROOT); do \
-		install -m 755 $$util.py $(DESTDIR)/usr/sbin/$$util; \
+		install -m 755 $$util.py $(DESTDIR)/usr/sbin/$$util-deprecated; \
 	done
 
 	for d in $(SUBDIRS); do make DESTDIR=`cd $(DESTDIR); pwd` -C $$d install; [ $$? = 0 ] || exit 1; done

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,11 +1,12 @@
-DOCS = repoquery package-cleanup repo-rss yumdownloader yum-builddep yum-changelog reposync \
-       yum-list-data yum-filter-data yum-verify yum-utils yum-aliases yum-debug-dump yum-versionlock \
-       yum-groups-manager debuginfo-install repodiff yum-fs-snapshot \
-       show-installed show-changed-rco yum-debug-restore \
-       find-repos-of-install needs-restarting repo-graph repoclosure \
-       repomanage repotrack verifytree yum-config-manager yum-ovl
+DOCS = yum-changelog yum-list-data yum-filter-data yum-verify yum-utils yum-aliases \
+       yum-versionlock yum-fs-snapshot yum-ovl
+DOCS_DEPRECATED = debuginfo-install find-repos-of-install needs-restarting package-cleanup \
+                  repoclosure repodiff repomanage repoquery repotrack reposync repo-graph \
+                  repo-rss verifytree yumdownloader yum-builddep yum-config-manager yum-debug-dump \
+                  yum-debug-restore yum-groups-manager show-installed show-changed-rco
 DOCS5 = yum-changelog.conf yum-versionlock.conf yum-fs-snapshot.conf
-DOCS8 = yum-complete-transaction yumdb yum-copr
+DOCS8 = yum-copr
+DOCS8_DEPRECATED = yum-complete-transaction yumdb
 
 all:
 	echo "Nothing to do"
@@ -20,10 +21,15 @@ install:
 	for doc in $(DOCS); do \
 		install -m 644 $$doc.1 $(DESTDIR)/usr/share/man/man1/; \
 	done
+	for doc in $(DOCS_DEPRECATED); do \
+		install -m 644 $$doc.1 $(DESTDIR)/usr/share/man/man1/$$doc-deprecated.1; \
+	done
 	for doc in $(DOCS5); do \
 		install -m 644 $$doc.5 $(DESTDIR)/usr/share/man/man5/; \
 	done
 	for doc in $(DOCS8); do \
 		install -m 644 $$doc.8 $(DESTDIR)/usr/share/man/man8/; \
 	done
-
+	for doc in $(DOCS8_DEPRECATED); do \
+		install -m 644 $$doc.8 $(DESTDIR)/usr/share/man/man8/$$doc-deprecated.8; \
+	done

--- a/yum-utils.spec
+++ b/yum-utils.spec
@@ -9,7 +9,7 @@
 
 Summary: Utilities based around the yum package manager
 Name: yum-utils
-Version: 1.1.31
+Version: 1.1.32
 Release: 1%{?dist}
 License: GPLv2+
 Group: Development/Tools
@@ -465,54 +465,54 @@ fi
 %doc COPYING
 %doc plugins/README
 %{_sysconfdir}/bash_completion.d
-%{_bindir}/debuginfo-install
-%{_bindir}/find-repos-of-install
-%{_bindir}/needs-restarting
-%{_bindir}/package-cleanup
-%{_bindir}/repoclosure
-%{_bindir}/repodiff
-%{_bindir}/repomanage
-%{_bindir}/repoquery
-%{_bindir}/repotrack
-%{_bindir}/reposync
-%{_bindir}/repo-graph
-%{_bindir}/repo-rss
-%{_bindir}/verifytree
-%{_bindir}/yumdownloader
-%{_bindir}/yum-builddep
-%{_bindir}/yum-config-manager
-%{_bindir}/yum-debug-dump
-%{_bindir}/yum-debug-restore
-%{_bindir}/yum-groups-manager
-%{_bindir}/show-installed
-%{_bindir}/show-changed-rco
-%{_sbindir}/yum-complete-transaction
-%{_sbindir}/yumdb
+%{_bindir}/debuginfo-install-deprecated
+%{_bindir}/find-repos-of-install-deprecated
+%{_bindir}/needs-restarting-deprecated
+%{_bindir}/package-cleanup-deprecated
+%{_bindir}/repoclosure-deprecated
+%{_bindir}/repodiff-deprecated
+%{_bindir}/repomanage-deprecated
+%{_bindir}/repoquery-deprecated
+%{_bindir}/repotrack-deprecated
+%{_bindir}/reposync-deprecated
+%{_bindir}/repo-graph-deprecated
+%{_bindir}/repo-rss-deprecated
+%{_bindir}/verifytree-deprecated
+%{_bindir}/yumdownloader-deprecated
+%{_bindir}/yum-builddep-deprecated
+%{_bindir}/yum-config-manager-deprecated
+%{_bindir}/yum-debug-dump-deprecated
+%{_bindir}/yum-debug-restore-deprecated
+%{_bindir}/yum-groups-manager-deprecated
+%{_bindir}/show-installed-deprecated
+%{_bindir}/show-changed-rco-deprecated
+%{_sbindir}/yum-complete-transaction-deprecated
+%{_sbindir}/yumdb-deprecated
 %{python_sitelib}/yumutils/
 %{_mandir}/man1/yum-utils.1.*
-%{_mandir}/man1/debuginfo-install.1.*
-%{_mandir}/man1/package-cleanup.1.*
-%{_mandir}/man1/repo-rss.1.*
-%{_mandir}/man1/repoquery.1.*
-%{_mandir}/man1/repodiff.1.*
-%{_mandir}/man1/reposync.1.*
-%{_mandir}/man1/show-changed-rco.1.*
-%{_mandir}/man1/show-installed.1.*
-%{_mandir}/man1/yum-builddep.1.*
-%{_mandir}/man1/yum-debug-dump.1.*
-%{_mandir}/man1/yum-debug-restore.1.*
-%{_mandir}/man8/yum-complete-transaction.8.*
-%{_mandir}/man1/yum-groups-manager.1.*
-%{_mandir}/man8/yumdb.8.*
-%{_mandir}/man1/yumdownloader.1.*
-%{_mandir}/man1/find-repos-of-install.1.*
-%{_mandir}/man1/needs-restarting.1.*
-%{_mandir}/man1/repo-graph.1.*
-%{_mandir}/man1/repoclosure.1.*
-%{_mandir}/man1/repomanage.1.*
-%{_mandir}/man1/repotrack.1.*
-%{_mandir}/man1/verifytree.1.*
-%{_mandir}/man1/yum-config-manager.1.*
+%{_mandir}/man1/debuginfo-install-deprecated.1.*
+%{_mandir}/man1/package-cleanup-deprecated.1.*
+%{_mandir}/man1/repo-rss-deprecated.1.*
+%{_mandir}/man1/repoquery-deprecated.1.*
+%{_mandir}/man1/repodiff-deprecated.1.*
+%{_mandir}/man1/reposync-deprecated.1.*
+%{_mandir}/man1/show-changed-rco-deprecated.1.*
+%{_mandir}/man1/show-installed-deprecated.1.*
+%{_mandir}/man1/yum-builddep-deprecated.1.*
+%{_mandir}/man1/yum-debug-dump-deprecated.1.*
+%{_mandir}/man1/yum-debug-restore-deprecated.1.*
+%{_mandir}/man8/yum-complete-transaction-deprecated.8.*
+%{_mandir}/man1/yum-groups-manager-deprecated.1.*
+%{_mandir}/man8/yumdb-deprecated.8.*
+%{_mandir}/man1/yumdownloader-deprecated.1.*
+%{_mandir}/man1/find-repos-of-install-deprecated.1.*
+%{_mandir}/man1/needs-restarting-deprecated.1.*
+%{_mandir}/man1/repo-graph-deprecated.1.*
+%{_mandir}/man1/repoclosure-deprecated.1.*
+%{_mandir}/man1/repomanage-deprecated.1.*
+%{_mandir}/man1/repotrack-deprecated.1.*
+%{_mandir}/man1/verifytree-deprecated.1.*
+%{_mandir}/man1/yum-config-manager-deprecated.1.*
 
 %files -n yum-updateonboot
 %defattr(-, root, root)


### PR DESCRIPTION
It is part of yum-dnf compatibility where dnf will provide original yum binaries
and yum-utils deprecated version.

Unfortunately it brakes bash-completion 