### PR TITLE
Fix warning when gpgcheck return code is >2

### DIFF
--- a/reposync.py
+++ b/reposync.py
@@ -320,7 +320,7 @@ def main():
                     elif result == 2:
                         my.logger.warning('Removing %s due to failed signature check.' % rpmfn)
                     else:
-                        my.logger.warning('Removing %s due to failed signature check: %s' % rpmfn)
+                        my.logger.warning('Removing %s due to failed signature check: %s' % (rpmfn, error))
                     os.unlink(pkg.localpath)
                     exit_code = 1
                     continue


### PR DESCRIPTION
If gpgcheck ever returns a code larger than 2, reposync will fail with:
(...)
    my.logger.warning('Removing %s due to failed signature check: %s' % rpmfn)
TypeError: not enough arguments for format string


I'm adding the 'error' variable to fix the number of arguments, as it seems to be expected:

    my.logger.warning('Removing %s due to failed signature check: %s' % (rpmfn, error))
