### PR TITLE
respect version specified in user packages 

### DIFF
--- a/repotrack.py
+++ b/repotrack.py
@@ -163,10 +163,12 @@ def main():
     unprocessed_pkgs = {}
     final_pkgs = {}
     pkg_list = []
-    
+    user_desired_list = [] 
     avail = my.pkgSack.returnPackages()
     for item in user_pkg_list:
         exactmatch, matched, unmatched = parsePackages(avail, [item])
+        user_desired_list.extend(exactmatch)  # packageName-x.y.z
+        user_desired_list.extend(matched)     # those with wildcard : e.g. packageName-x.*
         pkg_list.extend(exactmatch)
         pkg_list.extend(matched)
         if opts.newest:
@@ -215,6 +217,7 @@ def main():
         download_list = this_sack.returnNewestByNameArch()
         
     download_list.sort(key=lambda pkg: pkg.name)
+    download_list.extend(user_desired_list) #regardless the newest filter result
     for pkg in download_list:
         repo = my.repos.getRepo(pkg.repoid)
         remote = pkg.returnSimple('relativepath')


### PR DESCRIPTION
**Issue for original code**:

for example:

when if user command is  `repotrack  kubelet-1.10.5` or  `repotrack  kubelet-1.10.5*`, because there's kubelet 1.11 which is newer, and by-default `newest` flag is `True`, so user specified  kubelet-1.10.5 will never be downloaded.( will only download kubelet 1.11).

which will bring a lot of confusion.( User wants version 1.10.5 , but it's not working .)

the workaround without changing code is to specific `--newest` ,  `repotrack  --newest kubelet-1.10.5`. but the `1.10.5` is just not working ,it will download all other old kubelet packages which total size are huge .

**Fix of the code**

It's simply. just saving the "exact matched" packages, and regardless the `newest filtering` process, adding those "exact matched" packages to the final download list.


**Test done**
`python repotrack.py --download_path=/app/repo/packages kubelet-1.10.5`


```
.......
Downloading kubelet-1.11.2-0.x86_64.rpm
Downloading kubelet-1.10.5-0.x86_64.rpm
```

```
[root@xxxx /]# ls /app/repo/packages/*kubelet*
/app/repo/packages/kubelet-1.11.2-0.x86_64.rpm
/app/repo/packages/kubelet-1.10.5-0.x86_64.rpm
```
