### PR TITLE
Change reposync exit code on GPG key validation errors

### DIFF
--- a/docs/reposync.1
+++ b/docs/reposync.1
@@ -34,7 +34,7 @@ Can only be used when syncing a single repository (default is
 to add the reponame).
 .IP "\fB\-g, \-\-gpgcheck\fP"
 Remove packages that fail GPG signature checking after downloading.
-exit status is '1' if at least one package was removed.
+exit status is '2' if at least one package was removed.
 .IP "\fB\-u, \-\-urls\fP"
 Just list urls of what would be downloaded, don't download.
 .IP "\fB\-l, \-\-plugins\fP"

--- a/reposync.py
+++ b/reposync.py
@@ -352,7 +352,7 @@ def main():
                     else:
                         my.logger.warning('Removing %s due to failed signature check: %s' % rpmfn)
                     os.unlink(pkg.localpath)
-                    exit_code = 1
+                    exit_code = 2
                     continue
 
     my.closeRpmDB()


### PR DESCRIPTION
Reposync currently exists with exit code 1 when there are GPG validation errors, so it's impossible to differentiate them from "real" errors. This change makes it use exit code 2 instead. Fixes #38.