### PR TITLE
Handle RepoStorage.retrieveAllMD() exceptions. BZ 1476701

### DIFF
--- a/reposync.py
+++ b/reposync.py
@@ -172,7 +172,11 @@ def main():
     # and package files ... needs to be setup before .repos (ie. RHN/etc.).
     if not opts.quiet:
         my.repos.setProgressBar(TextMeter(fo=sys.stdout), TextMultiFileMeter(fo=sys.stdout))
-    my.doRepoSetup()
+    try:
+        my.doRepoSetup()
+    except yum.Errors.RepoError, e:
+        print >> sys.stderr, _("Error setting up repositories: %s") % e
+        sys.exit(1)
 
     if len(opts.repoid) > 0:
         myrepos = []

--- a/repotrack.py
+++ b/repotrack.py
@@ -159,7 +159,11 @@ def main():
         # enable the ones we like
         for repo in myrepos:
             repo.enable()
-            my._getSacks(archlist=archlist, thisrepo=repo.id)
+            try:
+                my._getSacks(archlist=archlist, thisrepo=repo.id)
+            except yum.Errors.RepoError, e:
+                my.logger.error(e)
+                sys.exit(1)
 
     if opts.repofrompath:
         for repo in opts.repofrompath:


### PR DESCRIPTION
Don't traceback in reposync or repotrack when the fetching of metadata
fails.

Note that both the doRepoSetup() and _getSacks() method calls lead to
doSetup() and then retrieveAllMD() where these exceptions may happen
(such as a bad metalink URL).