### PR TITLE
repotrack: fix --repofrompath. BZ 1659588

### DIFF
--- a/repotrack.py
+++ b/repotrack.py
@@ -135,6 +135,27 @@ def main():
         archlist.extend(rpmUtils.arch.getArchList(opts.arch))
     else:
         archlist = rpmUtils.arch.getArchList()
+
+    if opts.repofrompath:
+        for repo in opts.repofrompath:
+            tmp = tuple(repo.split(','))
+            if len(tmp) != 2:
+                my.logger.error("Error: Bad repofrompath argument: %s" %repo)
+                continue
+            repoid, repopath = tmp
+            if repopath and repopath[0] == '/':
+                baseurl = 'file://' + repopath
+            else:
+                baseurl = repopath
+            try:
+                my.add_enable_repo(repoid, baseurls=[baseurl],
+                                   basecachedir=my.conf.cachedir,
+                                   timestamp_check=False)
+            except yum.Errors.DuplicateRepoError, e:
+                my.logger.error(e)
+                sys.exit(1)
+            if not opts.quiet:
+                my.logger.info("Added %s repo from %s" % (repoid, repopath))
         
     # do the happy tmpdir thing if we're not root
     if os.geteuid() != 0 or opts.tempcache:
@@ -160,27 +181,6 @@ def main():
         for repo in myrepos:
             repo.enable()
             my._getSacks(archlist=archlist, thisrepo=repo.id)
-
-    if opts.repofrompath:
-        for repo in opts.repofrompath:
-            tmp = tuple(repo.split(','))
-            if len(tmp) != 2:
-                my.logger.error("Error: Bad repofrompath argument: %s" %repo)
-                continue
-            repoid, repopath = tmp
-            if repopath and repopath[0] == '/':
-                baseurl = 'file://' + repopath
-            else:
-                baseurl = repopath
-            try:
-                my.add_enable_repo(repoid, baseurls=[baseurl],
-                                   basecachedir=my.conf.cachedir,
-                                   timestamp_check=False)
-            except yum.Errors.DuplicateRepoError, e:
-                my.logger.error(e)
-                sys.exit(1)
-            if not opts.quiet:
-                my.logger.info("Added %s repo from %s" % (repoid, repopath))
 
     try:
         my.doRepoSetup()


### PR DESCRIPTION
There are two issues with the current implementation (that I didn't
realize when porting this feature from repoquery):

1) my.conf.cachedir may need to be changed to a user-specific path (the
   cachedir block sets this up for each enabled repo so why not take
   advantage of it); this came up as BZ 1659588

2) If --repoid is specified, we load the package sack accordingly but
   never reload it again.  This breaks the following use case:
   $ repotrack --repofrompath=foo,http://foo --repoid foo --repoid bar

This commit fixes both issues simply by moving the repofrompath code
block in front of the cachedir block (that's also how repoquery does it,
after all).