### PR TITLE
repotrack: copy local packages. BZ 1463723

### DIFF
--- a/repotrack.py
+++ b/repotrack.py
@@ -266,7 +266,7 @@ def main():
         if not opts.quiet:        
             my.logger.info('Downloading %s' % os.path.basename(remote))
         pkg.localpath = local # Hack: to set the localpath to what we want.
-        path = repo.getPackage(pkg)
+        path = repo.getPackage(pkg, copy_local=1)
 
         if not os.path.exists(local) or not os.path.samefile(path, local):
             shutil.copy2(path, local)


### PR DESCRIPTION
While we correctly set the target localpath on the package object, we
don't actually fetch (copy) the package itself if it's local.  This
fixes it.

Note that, for remote packages (without file://), this change has no
effect (see UrlGrabber.urlgrab() for the context).