### PR TITLE
Implement an option to keep only the N newest versions of a package

### DIFF
--- a/reposync.py
+++ b/reposync.py
@@ -126,6 +126,8 @@ def parseArgs():
         action="store_true",
         help=_("Allow packages stored outside their repo directory to be synced "
                "(UNSAFE, USE WITH CAUTION!)"))
+    parser.add_option("-k", "--keep-count", dest='keep', default=None, action="store_true",
+                      help=_("Only keep up to this many newest packages per-repo"))
     (opts, args) = parser.parse_args()
     return (opts, args)
 
@@ -218,6 +220,23 @@ def main():
 
         if opts.newest:
             download_list = reposack.returnNewestByNameArch()
+        elif opts.keep is not None:
+            unfiltered_list = list(reposack)
+            package_dict = dict()
+
+            for pkg in unfiltered_list:
+                package_dict.setdefault(pkg.name, []).append(pkg)
+
+            for name in package_dict:
+                newest_pkgs = sorted(package_dict[name])[-opts.keep:]
+                package_dict[name] = newest_pkgs
+
+            flattened_list = []
+            for package_list in package_dict.values():
+                for pkg in package_list:
+                    flattened_list.append(pkg)
+
+            download_list = flattened_list
         else:
             download_list = list(reposack)
 


### PR DESCRIPTION
This PR adds a long-requested option to keep a certain number of packages, instead of the all-or-one options that we have today.

Fixes #9.