### PR TITLE
needs-restarting: use new logic for setting reboot hint.

### DIFF
--- a/needs-restarting.py
+++ b/needs-restarting.py
@@ -151,7 +151,7 @@ def main(args):
 
     if opts.reboothint:
         needing_reboot = set()
-        for pkg in my.rpmdb.searchNames(REBOOTPKGS):
+        for pkg in { my.rpmdb.searchProvides(name) for name in REBOOTPKGS }:
             if float(pkg.installtime) > float(boot_time):
                 needing_reboot.add(pkg)
         if needing_reboot:


### PR DESCRIPTION
Before this change, if a system had an alternative kernel installed (ie: ELRepo's `kernel-ml` or `kernel-lt`) the logic in `needs-restarting` would not detect if that kernel package had been installed or updated. With this change, the reboot hint will be set if a package _providing_ any of `REBOOTPKGS` has been installed or updated since the system last booted.

This PR should fix #66.